### PR TITLE
fix: Replace emojis with plain text and add repository link to output

### DIFF
--- a/bin/git-sync
+++ b/bin/git-sync
@@ -99,7 +99,8 @@ class GitSync
      */
     private function runStandaloneCommand($args)
     {
-        echo "Git Sync (Standalone Mode)\n";
+        echo "Laravel Git Sync\n";
+        echo "https://github.com/Aarondio/laravel-git-sync\n";
         echo "\n";
 
         // Parse arguments
@@ -143,7 +144,7 @@ class GitSync
             return $this->pushChanges($options);
         }
 
-        echo "\n✓ Done! Changes committed successfully.\n";
+        echo "\n[OK] Done! Changes committed successfully.\n";
         return 0;
     }
 
@@ -245,7 +246,7 @@ class GitSync
     {
         $message = $options['message'] ?? $this->generateDefaultMessage();
 
-        echo "💾 Committing changes...\n";
+        echo "[*] Committing changes...\n";
 
         if ($options['verbose']) {
             echo "Message: {$message}\n";
@@ -261,7 +262,7 @@ class GitSync
             return false;
         }
 
-        echo "✓ Changes committed\n";
+        echo "[OK] Changes committed\n";
 
         if ($options['verbose']) {
             echo implode("\n", $output) . "\n";
@@ -296,7 +297,7 @@ class GitSync
             echo "\n";
         }
 
-        echo "⬆️  Pushing to remote...\n";
+        echo "[*] Pushing to remote...\n";
 
         if ($options['verbose']) {
             echo "Branch: {$branch}\n";
@@ -312,8 +313,8 @@ class GitSync
                 exec('git push -u origin ' . escapeshellarg($branch) . ' 2>&1', $output, $exitCode);
 
                 if ($exitCode === 0) {
-                    echo "✓ Changes pushed successfully\n";
-                    echo "\n✓ Done!\n";
+                    echo "[OK] Changes pushed successfully\n";
+                    echo "\n[OK] Done!\n";
                     return 0;
                 }
             }
@@ -325,13 +326,13 @@ class GitSync
             return 1;
         }
 
-        echo "✓ Changes pushed successfully\n";
+        echo "[OK] Changes pushed successfully\n";
 
         if ($options['verbose']) {
             echo implode("\n", $output) . "\n";
         }
 
-        echo "\n✓ Done!\n";
+        echo "\n[OK] Done!\n";
         return 0;
     }
 
@@ -369,7 +370,7 @@ class GitSync
             echo "  - git push origin {$branch}\n";
         }
 
-        echo "\n✓ Dry run completed.\n";
+        echo "\n[OK] Dry run completed.\n";
         return 0;
     }
 
@@ -417,7 +418,7 @@ class GitSync
             return false;
         }
 
-        echo "⬇️  Pulling changes from remote...\n";
+        echo "[*] Pulling changes from remote...\n";
 
         if ($options['verbose']) {
             echo "Branch: {$branch}\n";
@@ -442,7 +443,7 @@ class GitSync
             return false;
         }
 
-        echo "✓ Successfully pulled changes\n";
+        echo "[OK] Successfully pulled changes\n";
 
         if ($options['verbose']) {
             echo implode("\n", $output) . "\n";

--- a/src/Commands/GitSyncCommand.php
+++ b/src/Commands/GitSyncCommand.php
@@ -50,7 +50,8 @@ class GitSyncCommand extends Command
             return self::FAILURE;
         }
 
-        $this->info('=� Laravel Git Sync');
+        $this->info('Laravel Git Sync');
+        $this->line('https://github.com/Aarondio/laravel-git-sync');
         $this->newLine();
 
         // Push-only mode
@@ -98,7 +99,7 @@ class GitSyncCommand extends Command
      */
     protected function stageChanges(bool $dryRun, bool $verbose): bool
     {
-        $this->line('=� Staging changes...');
+        $this->line('[*] Staging changes...');
 
         if ($dryRun) {
             $this->info('[DRY RUN] Would execute: git add .');
@@ -140,7 +141,7 @@ class GitSyncCommand extends Command
     {
         $message = $this->getCommitMessage();
 
-        $this->line('=� Committing changes...');
+        $this->line('[*] Committing changes...');
 
         if ($verbose) {
             $this->line("Message: {$message}");

--- a/src/Commands/GitSyncInstallCommand.php
+++ b/src/Commands/GitSyncInstallCommand.php
@@ -44,7 +44,7 @@ class GitSyncInstallCommand extends Command
             $existingScript = $composer['scripts']['sync'];
 
             if ($existingScript === 'php artisan git:sync' || $existingScript === '@php artisan git:sync') {
-                $this->info('✓ The "composer sync" command is already configured!');
+                $this->info('[OK] The "composer sync" command is already configured!');
                 return self::SUCCESS;
             }
 
@@ -78,7 +78,7 @@ class GitSyncInstallCommand extends Command
         }
 
         $this->newLine();
-        $this->info('✓ Successfully added "composer sync" command to your project!');
+        $this->info('[OK] Successfully added "composer sync" command to your project!');
         $this->newLine();
         $this->line('You can now use:');
         $this->line('  <fg=green>composer sync</>                    # Quick sync');


### PR DESCRIPTION
- Fixed emoji encoding issues that displayed as question marks in terminals
- Replaced all emojis with plain text indicators ([*], [OK])
- Added repository link to output header for easy access
- Updated GitSyncCommand.php output formatting
- Updated GitSyncInstallCommand.php status messages
- Updated bin/git-sync standalone binary output
- Improves compatibility with all terminal types and encodings

Output now shows:
  Laravel Git Sync https://github.com/Aarondio/laravel-git-sync